### PR TITLE
outman_next: output_manager_initialize_files()

### DIFF
--- a/src/output/output_manager_core.F90
+++ b/src/output/output_manager_core.F90
@@ -28,6 +28,7 @@ module output_manager_core
    integer,parameter,public :: time_from_list   = 7
 
    integer,parameter,public :: rk = kind(_ONE_)
+   integer,parameter,public :: timestepkind = selected_int_kind(12)
 
    type,abstract :: type_host
    contains


### PR DESCRIPTION
with optional save_first argument sets first output time.
The latter is missing so far and mandatory (independent on save_first argument).
Imagine time_start much earlier than now_time. Until next_time exceeds now_time, every model timestep is output without this fix. save_first argument only adds on this.
calculation of first next_time is done in initialize_files(). this routine now became public as output_manager_initialize_files() and can be called directly from host (no need to provide save_first argument to prepare_save() or save()).