### PR TITLE
Fix two bugs in the Stokes drift module

### DIFF
--- a/src/stokes_drift/stokes_drift.F90
+++ b/src/stokes_drift/stokes_drift.F90
@@ -497,7 +497,7 @@
       ! turbulent Langmuir number (McWilliams et al., 1997)
       La_Turb = sqrt(u_taus/us_srf)
       ! surface layer averaged Langmuir number (Harcourt and D'Asaro, 2008)
-      La_SL = sqrt(u_taus/(sqrt(ussl**2+vssl**2) &
+      La_SL = sqrt(u_taus/abs(sqrt(ussl**2+vssl**2) &
                          -sqrt(usprof%data(kbl)**2+vsprof%data(kbl)**2) &
                          +SMALL*SMALL))
       ! angles between wind and waves

--- a/src/stokes_drift/stokes_drift.F90
+++ b/src/stokes_drift/stokes_drift.F90
@@ -493,7 +493,7 @@
       vssl = vs0%value
    end if
 
-   if (us_srf .gt. _ZERO_) then
+   if (us_srf .gt. 1e-4 .and. u_taus .gt. 1e-4) then
       ! turbulent Langmuir number (McWilliams et al., 1997)
       La_Turb = sqrt(u_taus/us_srf)
       ! surface layer averaged Langmuir number (Harcourt and D'Asaro, 2008)


### PR DESCRIPTION
This PR fixes two bugs in the Stokes drift module that in some cases the Langmuir numbers may be invalid values:
1. An invalid value of 0 could happen when the surface wind forcing is zero but the Stokes drift is not. This is now fixed by checking both the surface friction velocity `u_taus` and the surface magnitude of Stokes drift `us_srf` when computing the Langmuir numbers. A valid big number for Langmuir numbers is assigned when either `u_taus` or `us_srf` is very small (smaller than 1e-4).
2. An invalid value of NaN (taking the square root of a negative number) could happen for the surface layer averaged Langmuir number when the surface layer Stokes drift magnitude is smaller than that near the base of the boundary layer (could happen when a swell component exists that is to the opposite direction of the wind and cancels the wind wave component near the surface). This is fixed by taking the absolute value of the difference before taking the square root.