### PR TITLE
Update configuration format for CVMix

### DIFF
--- a/src/cvmix/gotm_cvmix.F90
+++ b/src/cvmix/gotm_cvmix.F90
@@ -372,10 +372,12 @@
    call leaf%get(use_kpp, 'use', 'use the K-Profile Parameterization', &
       default=.true.)
    call leaf%get(kpp_langmuir_method, 'langmuir_method',               &
-      'method of Langmuir turbulence pararmeterization', default=0,    &
-      options=(/option(0, 'none'), option(1, 'Li et al. (2016)'),      &
-      option(2, 'Li and Fox-Kemper (2017)'),                           &
-      option(3, 'Reichl et al. (2016)')/))
+      'method of Langmuir turbulence pararmeterization',               &
+      default=CVMIX_LT_NOLANGMUIR,                                     &
+      options=(/option(CVMIX_LT_NOLANGMUIR, 'none', 'none'),           &
+      option(CVMIX_LT_LWF16, 'Li et al. (2016)', 'LWF16'),             &
+      option(CVMIX_LT_LF17, 'Li and Fox-Kemper (2017)', 'LF17'),       &
+      option(CVMIX_LT_RWH16, 'Reichl et al. (2016)', 'RWH16')/))
    call leaf%get(kpp_surface_layer_extent, 'surface_layer_extent',     &
       'extent of surface layer in fraction of the boundary layer', '-',&
       minimum=0._rk, maximum=1._rk, default=0.1_rk)
@@ -390,21 +392,27 @@
    call leaf%get(kpp_use_noDGat1, 'use_noDGat1',                       &
       'zero gradient of the shape function at OBL', default=.true.)
    call leaf%get(kpp_match_technique, 'match_technique',               &
-      'matching technique with the ocean interior',                    &
-      default=1, options=(/                                            &
-      option(1, 'SimpleShapes'),                                       &
-      option(2, 'MatchGradient'),                                      &
-      option(3, 'MatchBoth'),                                          &
-      option(4, 'ParabolicNonLocal')/))
+      'matching technique of shape functions with the ocean interior', &
+      default=CVMIX_MATCH_SIMPLE, options=(/                           &
+      option(CVMIX_MATCH_SIMPLE, 'simple shapes', 'simple'),           &
+      option(CVMIX_MATCH_GRADIENT, 'gradient term', 'gradient'),       &
+      option(CVMIX_MATCH_BOTH,                                         &
+             'both gradient and nonlocal terms', 'both'),              &
+      option(CVMIX_MATCH_PARABOLIC,                                    &
+             'parabolic nonlocal term', 'parabolic')/))
    call leaf%get(kpp_bulk_Ri_interp_type, 'bulk_Ri_interp_type',       &
       'interpolation type for the bulk Richardson number',             &
-      default=2, options=(/                                            &
-      option(1, 'linear'), option(2, 'quadratic'), option(3, 'cubic')/))
+      default=CVMIX_INTERP_QUADRATIC, options=(/                       &
+      option(CVMIX_INTERP_LINEAR, 'linear', 'linear'),                 &
+      option(CVMIX_INTERP_QUADRATIC, 'quadratic', 'quadratic'),        &
+      option(CVMIX_INTERP_CUBIC, 'cubic', 'cubic')/))
    call leaf%get(kpp_OBL_interp_type, 'OBL_interp_type',               &
       'interpolation type for diffusivity and viscosity at OBL',       &
-      default=4, options=(/                                            &
-      option(1, 'linear'), option(2, 'quadratic'),                     &
-      option(3, 'cubic'), option(4, 'LMD94')/))
+      default=CVMIX_INTERP_LMD94, options=(/                           &
+      option(CVMIX_INTERP_LINEAR, 'linear', 'linear'),                 &
+      option(CVMIX_INTERP_QUADRATIC, 'quadratic', 'quadratic'),        &
+      option(CVMIX_INTERP_CUBIC, 'cubic', 'cubic'),                    &
+      option(CVMIX_INTERP_LMD94, 'LMD94', 'LMD94')/))
 
    twig => branch%get_child('interior', 'interior mixing')
    call twig%get(use_interior, 'use',                                  &
@@ -425,9 +433,9 @@
       'number of iterations to smooth the gradient Richardson number', &
       default=1)
    call leaf%get(shear_mix_scheme, 'mix_scheme', 'shear mixing scheme',&
-      default=2, options=(/                                            &
-      option(1, 'PP, Pacanowski and Philander (1981)'),                &
-      option(2, 'KPP, Large et al. (1994)')/))
+      default=CVMIX_SHEAR_KPP, options=(/                              &
+      option(CVMIX_SHEAR_PP, 'Pacanowski and Philander (1981)', 'PP'), &
+      option(CVMIX_SHEAR_KPP, 'Large et al. (1994)', 'KPP')/))
    call leaf%get(shear_PP_nu_zero, 'PP_nu_zero',                       &
       'numerator in viscosity term in PP', 'm^2/s',                    &
       default=0.005_rk)

--- a/src/cvmix/gotm_cvmix.F90
+++ b/src/cvmix/gotm_cvmix.F90
@@ -412,7 +412,7 @@
       option(CVMIX_INTERP_LINEAR, 'linear', 'linear'),                 &
       option(CVMIX_INTERP_QUADRATIC, 'quadratic', 'quadratic'),        &
       option(CVMIX_INTERP_CUBIC, 'cubic', 'cubic'),                    &
-      option(CVMIX_INTERP_LMD94, 'LMD94', 'LMD94')/))
+      option(CVMIX_INTERP_LMD94, 'Large et al. (1994)', 'LMD94')/))
 
    twig => branch%get_child('interior', 'interior mixing')
    call twig%get(use_interior, 'use',                                  &

--- a/src/stokes_drift/stokes_drift.F90
+++ b/src/stokes_drift/stokes_drift.F90
@@ -239,22 +239,18 @@
                    method_off=NOTHING, method_constant=method_unsupported, method_file=FROMFILE, &
                    extra_options=(/option(FROMUS, 'compute from vs', 'vs')/))
    twig => branch%get_typed_child('exponential', 'exponential Stokes drift profile defined by surface value and decay depth')
-   call twig%get(us0, 'us0', 'surface Stokes drift in West-East direction', 'm/s',   &
-                 method_off=NOTHING, method_constant=CONSTANT, method_file=FROMFILE, &
-                 minimum=0._rk, default=0._rk)
-   call twig%get(vs0, 'vs0', 'surface Stokes drift in South-North direction', 'm/s', &
-                 method_off=NOTHING, method_constant=CONSTANT, method_file=FROMFILE, &
-                 minimum=0._rk, default=0._rk)
+   call twig%get(us0, 'us0', 'surface Stokes drift in West-East direction', 'm/s',                &
+                 method_off=NOTHING, method_constant=CONSTANT, method_file=FROMFILE, default=0._rk)
+   call twig%get(vs0, 'vs0', 'surface Stokes drift in South-North direction', 'm/s',              &
+                 method_off=NOTHING, method_constant=CONSTANT, method_file=FROMFILE, default=0._rk)
    call twig%get(ds, 'ds', 'Stokes drift decay depth', 'm',                          &
                  method_off=NOTHING, method_constant=CONSTANT, method_file=FROMFILE, &
                  minimum=0._rk, default=5._rk)
    twig => branch%get_typed_child('empirical', 'approximate Stokes drift from empirical wave spectrum following Li et al., 2017')
    call twig%get(uwnd, 'uwnd', 'surface wind for Stokes drift in West-East direction', 'm/s',     &
-                 method_off=NOTHING, method_constant=CONSTANT, method_file=FROMFILE,              &
-                 minimum=0._rk, default=0._rk)
+                 method_off=NOTHING, method_constant=CONSTANT, method_file=FROMFILE, default=0._rk)
    call twig%get(vwnd, 'vwnd', 'surface wind for Stokes drift in South-North direction', 'm/s',   &
-                 method_off=NOTHING, method_constant=CONSTANT, method_file=FROMFILE,              &
-                 minimum=0._rk, default=0._rk)
+                 method_off=NOTHING, method_constant=CONSTANT, method_file=FROMFILE, default=0._rk)
 
    LEVEL2 'done'
 


### PR DESCRIPTION
This PR updates the configuration format for the CVMix module. It also fixes a bug in the Stokes drift module that a minimum value of 0.0 was incorrectly set for `us0`, `vs0`, `uwnd` and `vwnd`. For some reason the earlier version of the code I was using didn't check this minimum value so the cases were running fine with this bug. Fixing this bug doesn't change the results. 