### PR TITLE
FIX build with gfortran11

### DIFF
--- a/src/gotm/gotm.F90
+++ b/src/gotm/gotm.F90
@@ -180,14 +180,14 @@
    class (type_settings), pointer :: branch, twig
    integer, parameter :: rk = kind(_ONE_)
 
+   logical          ::    restart_allow_missing_variable = .false.
+   logical          ::    restart_allow_perpetual = .true.
+   logical          ::    restart_offline = .false.
    namelist /model_setup/ title,nlev,dt,restart_offline,restart_allow_missing_variable, &
                           restart_allow_perpetual,cnpar,buoy_method
    namelist /station/     name,latitude,longitude,depth
    namelist /time/        timefmt,MaxN,start,stop
    logical          ::    restart_online=.false.
-   logical          ::    restart_offline = .false.
-   logical          ::    restart_allow_missing_variable = .false.
-   logical          ::    restart_allow_perpetual = .true.
    integer          ::    rc
    logical          ::    file_exists
    logical          ::    config_only=.false.


### PR DESCRIPTION
Without this patch, with `gfortran 11.1.0`:

```bash
[...]/src/gotm/gotm.F90:184:56:

  184 |    namelist /model_setup/ title,nlev,dt,restart_offline,restart_allow_missing_variable, &
      |                                                        1
Error: Symbol ‘restart_offline’ in namelist ‘model_setup’ at (1) must be declared before the namelist is declared.
[...]/src/gotm/gotm.F90:184:87:

  184 | _setup/ title,nlev,dt,restart_offline,restart_allow_missing_variable, &
      |                                                                     1

Error: Symbol ‘restart_allow_missing_variable’ in namelist ‘model_setup’ at (1) must be declared before the namelist is declared.
[...]/src/gotm/gotm.F90:185:50:

  185 |                           restart_allow_perpetual,cnpar,buoy_method
      |                                                  1
Error: Symbol ‘restart_allow_perpetual’ in namelist ‘model_setup’ at (1) must be declared before the namelist is declared.
```