### PR TITLE
Include non-local mixing by default and clean up KPP preprocessor macros

### DIFF
--- a/include/cppdefs.h
+++ b/include/cppdefs.h
@@ -67,17 +67,3 @@
 #define NCDF_FLOAT_PRECISION NF90_REAL
 #define NCDF_REAL real(kind=selected_real_kind(6))
 #endif
-
-! non-local fluxes
-#undef NONLOCAL
-
-! KPP turbulence model
-#define KPP_SHEAR
-#define KPP_INTERNAL_WAVE
-#define KPP_CONVEC
-#undef KPP_DDMIX
-#undef KPP_TWOPOINT_REF
-#define KPP_IP_FC
-#undef KPP_CLIP_GS
-#define KPP_SALINITY
-

--- a/src/meanflow/salinity.F90
+++ b/src/meanflow/salinity.F90
@@ -116,7 +116,7 @@
 !  set boundary conditions
    DiffBcup       = Neumann
    DiffBcdw       = Neumann
-   DiffSup        = -S(nlev)*wflux-sflux  
+   DiffSup        = -S(nlev)*wflux-sflux
    DiffSdw        = _ZERO_
 
    AdvBcup       = oneSided
@@ -135,9 +135,7 @@
 
    do i=1,nlev
 !     from non-local turbulence
-#ifdef NONLOCAL
       Qsour(i) = Qsour(i) - ( gams(i) - gams(i-1) )/h(i)
-#endif
    end do
 
 !  ... and from lateral advection

--- a/src/meanflow/temperature.F90
+++ b/src/meanflow/temperature.F90
@@ -182,9 +182,7 @@
 
    do i=1,nlev
 !     from non-local turbulence
-#ifdef NONLOCAL
       Qsour(i) = Qsour(i) - ( gamh(i) - gamh(i-1) )/h(i)
-#endif
    end do
 
 !  ... and from lateral advection

--- a/src/meanflow/uequation.F90
+++ b/src/meanflow/uequation.F90
@@ -173,18 +173,16 @@
 #endif
 
 !     add non-local fluxes
-#ifdef NONLOCAL
 !      Qsour(i) = Qsour(i) - ( gamu(i) - gamu(i-1) )/h(i)
-#endif
 
    end do
 
 !  implement bottom friction as source term
    Lsour(1) = - drag(1)/h(1)*sqrt(u(1)*u(1)+v(1)*v(1))
 
-!  for surface plumes implement surface friction as source term 
+!  for surface plumes implement surface friction as source term
    if (int_press_type == 2 .and. plume_type .eq. 1) then
-      Lsour(nlev) = - drag(nlev)/h(nlev)*sqrt(u(nlev)*u(nlev)+v(nlev)*v(nlev)) 
+      Lsour(nlev) = - drag(nlev)/h(nlev)*sqrt(u(nlev)*u(nlev)+v(nlev)*v(nlev))
    end if
 
 !  do advection step

--- a/src/meanflow/vequation.F90
+++ b/src/meanflow/vequation.F90
@@ -152,18 +152,16 @@
 #endif
 
 !     add non-local fluxes
-#ifdef NONLOCAL
 !      Qsour(i) = Qsour(i) - ( gamv(i) - gamv(i-1) )/h(i)
-#endif
 
    end do
 
 !  implement bottom friction as source term
    Lsour(1) = - drag(1)/h(1)*sqrt(u(1)*u(1)+v(1)*v(1))
 
-!  for surface plumes implement surface friction as source term 
+!  for surface plumes implement surface friction as source term
    if (int_press_type == 2 .and. plume_type .eq. 1) then
-      Lsour(nlev) = - drag(nlev)/h(nlev)*sqrt(u(nlev)*u(nlev)+v(nlev)*v(nlev)) 
+      Lsour(nlev) = - drag(nlev)/h(nlev)*sqrt(u(nlev)*u(nlev)+v(nlev)*v(nlev))
    end if
 
 !  do advection step


### PR DESCRIPTION
This PR addresses the issue https://github.com/gotm-model/code/issues/32. Since `gam*` are all zero except when using CVMix, this shouldn't affect the results other than CVMix.