### PR TITLE
Add bottom layer in the CVMix module and clean up the Stokes drift module

### DIFF
--- a/src/cvmix/gotm_cvmix.F90
+++ b/src/cvmix/gotm_cvmix.F90
@@ -1431,7 +1431,7 @@
    call cvmix_kpp_compute_OBL_depth(CVmix_vars)
 
    ! CVMix returns a BoundaryLayerDepth > 0
-   zsbl = -CVmix_vars%BoundaryLayerDepth
+   zsbl = z_w(nlev)-CVmix_vars%BoundaryLayerDepth
 
 !-----------------------------------------------------------------------
 !  Update surface buoyancy flux in the new surface boundary layer
@@ -1653,7 +1653,7 @@
 !  first find old boundary layer index "kbbl".
    kbbl=nlev
    do k=1,nlev
-      if ((kbbl.eq.nlev).and.(z_w(k).lt.zbbl)) then
+      if ((kbbl.eq.nlev).and.(z_w(k).gt.zbbl)) then
          kbbl = k
       endif
    enddo

--- a/src/cvmix/gotm_cvmix.F90
+++ b/src/cvmix/gotm_cvmix.F90
@@ -729,7 +729,7 @@
 ! !IROUTINE: Do KPP with CVMix
 !
 ! !INTERFACE:
-   subroutine do_cvmix(nlev,h0,h,rho,u,v,NN,NNT,NNS,SS,u_taus,         &
+   subroutine do_cvmix(nlev,h0,h,rho,u,v,NN,NNT,NNS,SS,u_taus,u_taub,  &
                        tFlux,btFlux,sFlux,bsFlux,tRad,bRad,f,          &
                        EFactor,LaSL)
 !
@@ -765,8 +765,8 @@
 !  square of shear frequency (1/s^2)
    REALTYPE, intent(in)                          :: SS(0:nlev)
 
-!  surface friction velocities (m/s)
-   REALTYPE, intent(in)                          :: u_taus
+!  surface and bottom friction velocities (m/s)
+   REALTYPE, intent(in)                          :: u_taus,u_taub
 
 !  surface temperature flux (K m/s) and
 !  salinity flux (psu m/s) (negative for loss)

--- a/src/cvmix/gotm_cvmix.F90
+++ b/src/cvmix/gotm_cvmix.F90
@@ -46,6 +46,9 @@
 ! z-position of surface boundary layer depth
   REALTYPE, public                       ::    zsbl
 
+! z-position of bottom boundary layer depth
+  REALTYPE, public                       ::    zbbl
+
 ! !DEFINED PARAMETERS:
 !
 !  method of Langmuir turbulence parameterization
@@ -694,6 +697,7 @@
 
    ! initialize boundary layer
    zsbl = _ZERO_
+   zbbl = _ZERO_
 
    ! initialize CVMix variables
    call cvmix_put(CVmix_vars, 'nlev', nlev)
@@ -848,8 +852,7 @@
 !-----------------------------------------------------------------------
 
    if (use_bottom_layer) then
-      call bottom_layer(nlev,h,rho,u,v,NN,u_taus,                    &
-                         tFlux,btFlux,sFlux,bsFlux,tRad,bRad,f)
+      call bottom_layer(nlev,h,rho,u,v,NN,u_taub,tRad,bRad,f)
    endif
 
 !-----------------------------------------------------------------------
@@ -1360,8 +1363,7 @@
 ! !IROUTINE: Compute turbulence in the bottom layer with CVMix
 !
 ! !INTERFACE:
-   subroutine bottom_layer(nlev,h,rho,u,v,NN,u_taus,                   &
-                            tFlux,btFlux,sFlux,bsFlux,tRad,bRad,f)
+   subroutine bottom_layer(nlev,h,rho,u,v,NN,u_taub,tRad,bRad,f)
 !
 ! !DESCRIPTION:
 ! In this routine all computations related to turbulence in the bottom layer
@@ -1386,16 +1388,8 @@
 !  square of buoyancy frequency (1/s^2)
    REALTYPE, intent(in)                          :: NN(0:nlev)
 
-!  surface friction velocities (m/s)
-   REALTYPE, intent(in)                          :: u_taus
-
-!  surface temperature flux (K m/s) and
-!  salinity flux (sal m/s) (negative for loss)
-   REALTYPE, intent(in)                          :: tFlux,sFlux
-
-!  surface buoyancy fluxes (m^2/s^3) due to
-!  heat and salinity fluxes
-   REALTYPE, intent(in)                          :: btFlux,bsFlux
+!  bottom friction velocities (m/s)
+   REALTYPE, intent(in)                          :: u_taub
 
 !  radiative flux [ I(z)/(rho Cp) ] (K m/s)
 !  and associated buoyancy flux (m^2/s^3)
@@ -1414,6 +1408,27 @@
 ! !LOCAL VARIABLES:
    integer                      :: k,ksbl
    integer                      :: kk,kref,kp1
+
+   REALTYPE                     :: Bo,Bfsfc
+   REALTYPE                     :: tRadSrf
+   REALTYPE                     :: bRadSrf,bRadSbl
+   REALTYPE                     :: wm, ws
+   REALTYPE                     :: depth
+   REALTYPE                     :: Rk, Rref
+   REALTYPE                     :: Uk, Uref, Vk, Vref
+   REALTYPE                     :: bRad_cntr
+   REALTYPE                     :: NN_max
+
+
+   REALTYPE, dimension (0:nlev) :: Bflux
+   REALTYPE, dimension (0:nlev) :: RiBulk
+
+!  Thickness of surface layer
+   REALTYPE                     :: surfthick
+
+!-----------------------------------------------------------------------
+!BOC
+!
 
    return
 

--- a/src/gotm/gotm.F90
+++ b/src/gotm/gotm.F90
@@ -255,7 +255,7 @@
                    default='2017-01-01 00:00:00')
    call branch%get(stop, 'stop', 'stop date and time', units='yyyy-mm-dd HH:MM:SS', &
                    default='2018-01-01 00:00:00')
-   if (generate_restart_file) stop = start 
+   if (generate_restart_file) stop = start
    call branch%get(dt, 'dt', 'time step for integration', 's', &
                    minimum=0.e-10_rk, default=3600._rk)
    call branch%get(cnpar, 'cnpar', '"implicitness" of diffusion scheme', '1', &
@@ -294,7 +294,7 @@
    call twig%get(dtgrid, 'dtgrid', 'time step (must be fraction of dt)', 's', &
                  minimum=0._rk,default=5._rk)
 #endif
-   
+
 
    ! Predefine order of top-level categories in gotm.yaml
    branch => settings_store%get_child('temperature')
@@ -373,7 +373,7 @@
                  default=0.00075_rk)
    call twig%get(cp, 'cp', 'specific heat capacity', 'J/(kg/K)', &
                  minimum=0._rk,default=3991.86796_rk)
-   
+
 
    LEVEL1 'init_density()'
    call init_density(nlev)
@@ -746,7 +746,7 @@
             call set_ssuv(u(nlev),v(nlev))
 #ifdef _ICE_
          else
-            call set_sst(Tice_surface) !GSW_KB - check for GSW alternative 
+            call set_sst(Tice_surface) !GSW_KB - check for GSW alternative
             call set_ssuv(_ZERO_,_ZERO_)
 #endif
          end if
@@ -839,7 +839,7 @@
 !  update shear and stratification
    call shear(nlev,cnpar)
    call do_density(nlev,S,T,-z,-zi)
-   buoy(1:nlev) = -gravity*(rho_p(1:nlev)-rho0)/rho0  
+   buoy(1:nlev) = -gravity*(rho_p(1:nlev)-rho0)/rho0
    call stratification(nlev)
 
 #ifdef SPM
@@ -863,7 +863,7 @@
 
          ! update Langmuir number
          call langmuir_number(nlev,zi,Hs_input%value,u_taus,zi(nlev)-zsbl,u10_input%value,v10_input%value)
-         
+
          select case(kpp_langmuir_method)
          case (0)
             efactor = _ONE_
@@ -879,9 +879,9 @@
             La = La_SLP_RWH16
          end select
 
-         !  update turbulence parameter from CVMIX 
-         call do_cvmix(nlev,depth,h,rho_p,u,v,NN,NNT,NNS,SS,            &
-                       u_taus,tFlux,btFlux,sFlux,bsFlux,                &
+         !  update turbulence parameter from CVMix
+         call do_cvmix(nlev,depth,h,rho,u,v,NN,NNT,NNS,SS,              &
+                       u_taus,u_taub,tFlux,btFlux,sFlux,bsFlux,         &
                        tRad,bRad,cori,efactor,La)
 #endif
 

--- a/src/gotm/gotm.F90
+++ b/src/gotm/gotm.F90
@@ -67,7 +67,7 @@
 
 #ifdef _CVMIX_
    use gotm_cvmix,  only: init_cvmix, post_init_cvmix, do_cvmix, clean_cvmix
-   use gotm_cvmix,  only: zsbl, kpp_langmuir_method
+   use gotm_cvmix,  only: zsbl, sbl_langmuir_method
 #endif
 
 #ifdef SEAGRASS
@@ -855,16 +855,16 @@
 !     compute turbulent mixing
       select case (turb_method)
 #ifdef _CVMIX_
-      ! use KPP implemenatation in CVMIX
+      ! use KPP implemenatation in CVMix
       case (100)
 
-         ! convert thermodynamic fluxes to what is needed by CVMIX
+         ! convert thermodynamic fluxes to what is needed by CVMix
          call convert_fluxes(nlev,gravity,swf,shf,ssf,rad,T(nlev),S(nlev),tFlux,sFlux,btFlux,bsFlux,tRad,bRad)
 
          ! update Langmuir number
          call langmuir_number(nlev,zi,Hs_input%value,u_taus,zi(nlev)-zsbl,u10_input%value,v10_input%value)
 
-         select case(kpp_langmuir_method)
+         select case(sbl_langmuir_method)
          case (0)
             efactor = _ONE_
             La = _ONE_/SMALL

--- a/src/gotm/gotm.F90
+++ b/src/gotm/gotm.F90
@@ -880,7 +880,7 @@
          end select
 
          !  update turbulence parameter from CVMix
-         call do_cvmix(nlev,depth,h,rho,u,v,NN,NNT,NNS,SS,              &
+         call do_cvmix(nlev,depth,h,rho_p,u,v,NN,NNT,NNS,SS,            &
                        u_taus,u_taub,tFlux,btFlux,sFlux,bsFlux,         &
                        tRad,bRad,cori,efactor,La)
 #endif

--- a/src/stokes_drift/stokes_drift.F90
+++ b/src/stokes_drift/stokes_drift.F90
@@ -347,7 +347,7 @@
 !-----------------------------------------------------------------------
 ! !LOCAL VARIABLES:
    REALTYPE, parameter                 :: kappa = 0.4
-   integer                             :: k, kk, ksl, kbl
+   integer                             :: k, ksl, kbl
    REALTYPE                            :: ussl, vssl, us_srf
    REALTYPE                            :: hsl, dz, z0
 !
@@ -362,17 +362,19 @@
    hsl = 0.2*hbl
 
 !  determine which layer contains surface layer
-   do kk = nlev,k,-1
-      if (zi(nlev)-zi(kk-1) .ge. hsl) then
-         ksl = kk
+   ksl = 1
+   do k = nlev,1,-1
+      if (zi(nlev)-zi(k-1) .ge. hsl) then
+         ksl = k
          exit
       end if
    end do
 
 !  determine which layer contains boundary layer
-   do kk = nlev,k,-1
-      if (zi(nlev)-zi(kk-1) .ge. hbl) then
-         kbl = kk
+   kbl = 1
+   do k = nlev,1,-1
+      if (zi(nlev)-zi(k-1) .ge. hbl) then
+         kbl = k
          exit
       end if
    end do
@@ -381,10 +383,10 @@
    if (ksl < nlev) then
       ussl =   usprof%data(ksl)*(hsl+zi(ksl))
       vssl =   vsprof%data(ksl)*(hsl+zi(ksl))
-      do kk = nlev,ksl+1,-1
-         dz = zi(kk)-zi(kk-1)
-         ussl = ussl + usprof%data(kk)*dz
-         vssl = vssl + vsprof%data(kk)*dz
+      do k = nlev,ksl+1,-1
+         dz = zi(k)-zi(k-1)
+         ussl = ussl + usprof%data(k)*dz
+         vssl = vssl + vsprof%data(k)*dz
       end do
       ussl = ussl/hsl
       vssl = vssl/hsl

--- a/src/stokes_drift/stokes_drift.F90
+++ b/src/stokes_drift/stokes_drift.F90
@@ -124,6 +124,10 @@
    LEVEL1 'init_stokes_drift_yaml'
 
    branch => settings_store%get_typed_child('waves/stokes_drift', 'observed/prescribed Stokes drift', display=display_advanced)
+   call branch%get(us0, 'us0', 'surface Stokes drift in West-East direction', 'm/s',                &
+                 method_off=NOTHING, method_constant=CONSTANT, method_file=FROMFILE, default=0._rk)
+   call branch%get(vs0, 'vs0', 'surface Stokes drift in South-North direction', 'm/s',              &
+                 method_off=NOTHING, method_constant=CONSTANT, method_file=FROMFILE, default=0._rk)
    call branch%get(usprof, 'us', 'Stokes drift in West-East direction', 'm/s', default=0._rk,    &
                    method_off=NOTHING, method_constant=method_unsupported, method_file=FROMFILE, &
                    extra_options=(/option(EXPONENTIAL, 'exponential profile', 'exponential'), &
@@ -139,10 +143,6 @@
                    method_off=NOTHING, method_constant=method_unsupported, method_file=FROMFILE, &
                    extra_options=(/option(FROMUS, 'compute from vs', 'vs')/))
    twig => branch%get_typed_child('exponential', 'exponential Stokes drift profile defined by surface value and decay depth')
-   call twig%get(us0, 'us0', 'surface Stokes drift in West-East direction', 'm/s',                &
-                 method_off=NOTHING, method_constant=CONSTANT, method_file=FROMFILE, default=0._rk)
-   call twig%get(vs0, 'vs0', 'surface Stokes drift in South-North direction', 'm/s',              &
-                 method_off=NOTHING, method_constant=CONSTANT, method_file=FROMFILE, default=0._rk)
    call twig%get(ds, 'ds', 'Stokes drift decay depth', 'm',                          &
                  method_off=NOTHING, method_constant=CONSTANT, method_file=FROMFILE, &
                  minimum=0._rk, default=5._rk)
@@ -189,18 +189,23 @@
 
    LEVEL2 'allocation stokes_drift memory..'
 
+   ! surface Stokes drift
+   call register_input(us0)
+   call register_input(vs0)
    ! Stokes drift profile
    call register_input(usprof)
    call register_input(vsprof)
+   ! Stokes drift shear profile
+   call register_input(dusdz)
+   call register_input(dvsdz)
 
    select case (usprof%method)
       case (NOTHING)
          LEVEL2 'Stokes drift off.'
       case (FROMFILE)
+         LEVEL2 'Reading Stokes drift profile from file.'
       case (EXPONENTIAL)
          LEVEL2 'Using exponential Stokes drift profile.'
-         call register_input(us0)
-         call register_input(vs0)
          call register_input(ds)
       case (THEORYWAVE)
          LEVEL2 'Using Stokes drift estimated from the theory-wave of Li et al. (2017)'
@@ -213,10 +218,6 @@
          LEVEL1 'A non-valid us_prof_method has been given ', usprof%method
          stop 'init_stokes_drift()'
    end select
-
-   ! Stokes drift shear profile
-   call register_input(dusdz)
-   call register_input(dvsdz)
 
    ! Langmuir number
    La_Turb = _ONE_/SMALL
@@ -272,17 +273,8 @@
 !-----------------------------------------------------------------------
 !BOC
 
+   ! Stokes drift profile
    select case (usprof%method)
-      case (FROMFILE)
-         ! usprof and vsprof already read from file
-         us0%value = usprof%data(nlev)
-         vs0%value = vsprof%data(nlev)
-         ! Stokes transport
-         ustran = _ZERO_
-         do k=1,nlev
-            ustran = ustran + sqrt(usprof%data(k)**2+vsprof%data(k)**2)*(zi(k)-zi(k-1))
-         end do
-         ds%value = ustran/max(SMALL, sqrt(us0%value**2.+vs0%value**2.))
       case (EXPONENTIAL)
          call stokes_drift_exp(nlev,z,zi)
       case (THEORYWAVE)
@@ -291,6 +283,13 @@
          else
             call stokes_drift_theory(nlev,z,zi,uwnd%value,vwnd%value,gravity)
          endif
+      case DEFAULT
+         ! Stokes transport
+         ustran = _ZERO_
+         do k=1,nlev
+            ustran = ustran + sqrt(usprof%data(k)**2+vsprof%data(k)**2)*(zi(k)-zi(k-1))
+         end do
+         ds%value = ustran/max(SMALL, sqrt(us0%value**2.+vs0%value**2.))
    end select
 
    ! Stokes shear
@@ -390,8 +389,8 @@
       ussl = ussl/hsl
       vssl = vssl/hsl
    else
-      ussl = us0%value
-      vssl = vs0%value
+      ussl = usprof%data(nlev)
+      vssl = vsprof%data(nlev)
    end if
 
    if (us_srf .gt. 1e-4 .and. u_taus .gt. 1e-4) then

--- a/src/stokes_drift/stokes_drift.F90
+++ b/src/stokes_drift/stokes_drift.F90
@@ -125,14 +125,14 @@
 
    branch => settings_store%get_typed_child('waves/stokes_drift', 'observed/prescribed Stokes drift', display=display_advanced)
    call branch%get(us0, 'us0', 'surface Stokes drift in West-East direction', 'm/s',                &
-                 method_off=NOTHING, method_constant=CONSTANT, method_file=FROMFILE, default=0._rk)
+                   method_off=NOTHING, method_constant=CONSTANT, method_file=FROMFILE, default=0._rk)
    call branch%get(vs0, 'vs0', 'surface Stokes drift in South-North direction', 'm/s',              &
-                 method_off=NOTHING, method_constant=CONSTANT, method_file=FROMFILE, default=0._rk)
-   call branch%get(usprof, 'us', 'Stokes drift in West-East direction', 'm/s', default=0._rk,    &
+                   method_off=NOTHING, method_constant=CONSTANT, method_file=FROMFILE, default=0._rk)
+   call branch%get(usprof, 'us', 'Stokes drift profile in West-East direction', 'm/s', default=0._rk,    &
                    method_off=NOTHING, method_constant=method_unsupported, method_file=FROMFILE, &
                    extra_options=(/option(EXPONENTIAL, 'exponential profile', 'exponential'), &
                                    option(THEORYWAVE, 'empirical theory-wave of Li et al., 2017', 'empirical')/))
-   call branch%get(vsprof, 'vs', 'Stokes drift in South-North direction', 'm/s', default=0._rk,  &
+   call branch%get(vsprof, 'vs', 'Stokes drift profile in South-North direction', 'm/s', default=0._rk,  &
                    method_off=NOTHING, method_constant=method_unsupported, method_file=FROMFILE, &
                    extra_options=(/option(EXPONENTIAL, 'exponential profile', 'exponential'), &
                                    option(THEORYWAVE, 'empirical theory-wave of Li et al., 2017', 'empirical')/))
@@ -146,7 +146,7 @@
    call twig%get(ds, 'ds', 'Stokes drift decay depth', 'm',                          &
                  method_off=NOTHING, method_constant=CONSTANT, method_file=FROMFILE, &
                  minimum=0._rk, default=5._rk)
-   twig => branch%get_typed_child('empirical', 'approximate Stokes drift from empirical wave spectrum following Li et al., 2017')
+   twig => branch%get_typed_child('empirical', 'approximate Stokes drift profile from empirical wave spectrum following Li et al., 2017')
    call twig%get(uwnd, 'uwnd', 'surface wind for Stokes drift in West-East direction', 'm/s',     &
                  method_off=NOTHING, method_constant=CONSTANT, method_file=FROMFILE, default=0._rk)
    call twig%get(vwnd, 'vwnd', 'surface wind for Stokes drift in South-North direction', 'm/s',   &
@@ -201,14 +201,14 @@
 
    select case (usprof%method)
       case (NOTHING)
-         LEVEL2 'Stokes drift off.'
+         LEVEL2 'Stokes drift profile off.'
       case (FROMFILE)
          LEVEL2 'Reading Stokes drift profile from file.'
       case (EXPONENTIAL)
          LEVEL2 'Using exponential Stokes drift profile.'
          call register_input(ds)
       case (THEORYWAVE)
-         LEVEL2 'Using Stokes drift estimated from the theory-wave of Li et al. (2017)'
+         LEVEL2 'Using Stokes drift profile approximated by the theory-wave approach of Li et al. (2017)'
          call register_input(uwnd)
          call register_input(vwnd)
       case (CONSTANT)

--- a/src/stokes_drift/stokes_drift_exp.F90
+++ b/src/stokes_drift/stokes_drift_exp.F90
@@ -43,9 +43,9 @@
       dz = zi(k)-zi(k-1)
       kdz = 0.5*dz/ds%value
       if (kdz .lt. 100.) then
-          tmp = sinh(kdz)/kdz*exp(z(k)/ds%value)
+          tmp = sinh(kdz)/kdz*exp((z(k)-zi(nlev))/ds%value)
       else
-          tmp = exp(z(k)/ds%value)
+          tmp = exp((z(k)-zi(nlev))/ds%value)
       end if
       usprof%data(k) = tmp*us0%value
       vsprof%data(k) = tmp*vs0%value

--- a/src/stokes_drift/stokes_drift_theory.F90
+++ b/src/stokes_drift/stokes_drift_theory.F90
@@ -62,8 +62,8 @@
       usprof%data(k) = tmp * xcomp
       vsprof%data(k) = tmp * ycomp
    enddo
-   us0%value = us0_to_u10 * wind_speed * xcomp
-   vs0%value = us0_to_u10 * wind_speed * ycomp
+   us0%value = us0_to_u10 * u10
+   vs0%value = us0_to_u10 * v10
    ds%value = stokes_srf(0)*abs(zi(0))/max(SMALL, sqrt(us0%value**2.+vs0%value**2.))
 
    return

--- a/src/stokes_drift/stokes_drift_theory.F90
+++ b/src/stokes_drift/stokes_drift_theory.F90
@@ -52,7 +52,7 @@
 
 !  compute surface layer averaged Stokes drift
    do k=0,nlev
-      call stokes_drift_theory_srf(wind_speed,zi(k),gravity,stokes_srf(k))
+      call stokes_drift_theory_srf(wind_speed,zi(k),gravity,us0_to_u10,stokes_srf(k))
    enddo
 
 !  compute Stokes drift profile
@@ -61,8 +61,8 @@
       usprof%data(k) = tmp * xcomp
       vsprof%data(k) = tmp * ycomp
    enddo
-   us0%value = usprof%data(nlev)
-   vs0%value = vsprof%data(nlev)
+   us0%value = us0_to_u10 * wind_speed * xcomp
+   vs0%value = us0_to_u10 * wind_speed * ycomp
    ds%value = stokes_srf(0)*abs(zi(0))/max(SMALL, sqrt(us0%value**2.+vs0%value**2.))
 
    return
@@ -76,7 +76,7 @@
 ! !IROUTINE: stokes_drift_theory_srf
 !
 ! !INTERFACE:
-   subroutine stokes_drift_theory_srf(u10,z_srf,gravity,stokes_srf)
+   subroutine stokes_drift_theory_srf(u10,z_srf,gravity,us0_to_u10,stokes_srf)
 ! !DESCRIPTION:
 !   Return the Stokes drift averaged over the surface layer
 !
@@ -92,6 +92,8 @@
    REALTYPE, intent(in)                 :: z_srf
 ! gravity
    REALTYPE, intent(in)                 :: gravity
+! ratio of surface Stokes drift to U10
+   REALTYPE, intent(in)                 :: us0_to_u10
 ! !OUTPUT PARAMETERS:
    REALTYPE, intent(out)                :: stokes_srf
 
@@ -107,8 +109,6 @@
    ! ratio of mean frequency to peak frequency for
    ! Pierson-Moskowitz spectrum (Webb, 2011)
    fm_to_fp = 1.296, &
-   ! ratio of surface Stokes drift to U10
-   us0_to_u10 = 0.0162, &
    ! loss ratio of Stokes transport
    r_loss = 0.667
 

--- a/src/stokes_drift/stokes_drift_theory.F90
+++ b/src/stokes_drift/stokes_drift_theory.F90
@@ -51,13 +51,14 @@
    ycomp = v10 / wind_speed
 
 !  compute surface layer averaged Stokes drift
-   do k=0,nlev
-      call stokes_drift_theory_srf(wind_speed,zi(k),gravity,us0_to_u10,stokes_srf(k))
+   do k=0,nlev-1
+      call stokes_drift_theory_srf(wind_speed,(zi(nlev)-zi(k)),gravity,us0_to_u10,stokes_srf(k))
    enddo
+   stokes_srf(nlev) = _ZERO_
 
 !  compute Stokes drift profile
    do k=1,nlev
-      tmp = ( stokes_srf(k-1)*zi(k-1)-stokes_srf(k)*zi(k) ) / (zi(k-1) - zi(k))
+      tmp = ( stokes_srf(k-1)*(zi(nlev)-zi(k-1))-stokes_srf(k)*(zi(nlev)-zi(k)) ) / (zi(k) - zi(k-1))
       usprof%data(k) = tmp * xcomp
       vsprof%data(k) = tmp * ycomp
    enddo


### PR DESCRIPTION
This PR brings two changes in the CVMix module and Stokes drift module.

1. Support of bottom layer mixing through CVMix. The CVMix parameters for the bottom layer are separate from those in the surface layer. So an additional section of `cvmix/bottom_layer` is added in the YAML file. The original `cvmix/surface_layer` section is also adjusted to make it simple. So the `cvmix/surface_layer` section of old YAML configuration files need to be updated.
2. Require input of surface Stokes drift `us0` and `vs0` if Stokes drift is read from a file. This allows better representation of the Stokes drift shear near the surface. The Stokes drift profile `usprof` and `vsprof` are treated as the layer-averaged Stokes drift over the grid cell. Previously, if Stokes drift profile is read from a file, surface Stokes drift was simply taken as the value at the top cell, i.e., `us0 = usprof(nlev)`. This underestimates the surface Stokes drift and may cause errors if surface Stokes drift is used in the model. This change does not affect the results of the KPP-based Langmuir turbulence parameterization currently implemented in CVMix since in those parameterizations the surface layer averaged Stokes drift is used rather than the surface value. But the `waves/stokes_drift` section of the YAML configuration file needs to be updated.

Also included in this PR is the fix to some bugs in the CVMix and Stokes drift modules, which didn't seem to cause any issues in my previous tests but may be problematic under certain conditions.