### PR TITLE
standard input for longwave

### DIFF
--- a/src/airsea/airsea.F90
+++ b/src/airsea/airsea.F90
@@ -281,7 +281,7 @@
    call branch%get(I_0, 'swr', 'shortwave radiation', 'W/m^2', &
                 minimum=0._rk,default=0._rk, method_constant=1, method_file=2, extra_options=(/option(3, 'from time, location and cloud cover', 'calculate')/))
    call branch%get(ql_input, 'longwave_radiation', 'net longwave radiation', 'W/m^2', &
-                default=0._rk, method_file=0, method_constant=method_unsupported, &
+                default=0._rk, &
                extra_options=(/option(CLARK, 'Clark et al. (1974)', 'Clark'), option(HASTENRATH_LAMB, 'Hastenrath and Lamb (1978)', 'Hastenrath_Lamb'), option(BIGNAMI, 'Bignami et al. (1995)', 'Bignami'), option(BERLIAND_BERLIAND, 'Berliand and Berliand (1952)', 'Berliand_Berliand'), option(JOSEY1, 'Josey et al. (2003) - 1', 'Josey1'), option(JOSEY2, 'Josey et al. (2003) - 2', 'Josey2')/), default_method=CLARK)
 
    twig => branch%get_typed_child('albedo')
@@ -475,9 +475,8 @@
          case default
       end select
       LEVEL3 'net longwave radiation:'
+      call register_input(ql_input)
       select case (ql_input%method)
-         case(0) ! Read from file instead of calculating
-            call register_input(ql_input)
          case(CLARK)
             LEVEL4 'using Clark formulation'
          case(HASTENRATH_LAMB)
@@ -773,7 +772,7 @@
       cloud1 = cloud2
 
       call humidity(hum_method,hum_input,airp_input,tw,ta)
-      if (ql_input%method .gt. 0) then
+      if (ql_input%method .gt. 2) then
          call longwave_radiation(ql_input%method, &
                                  dlat,tw_k,ta_k,cloud,ql_input)
       end if
@@ -825,7 +824,7 @@
    end if
 
    call humidity(hum_method,hum_input%value,airp_input%value,tw,ta)
-   if (ql_input%method .gt. 0) then
+   if (ql_input%method .gt. 2) then
       call longwave_radiation(ql_input%method, &
                           dlat,tw_k,ta_k,cloud_input%value,ql_input%value)
    endif

--- a/src/airsea/airsea_variables.F90
+++ b/src/airsea/airsea_variables.F90
@@ -46,12 +46,12 @@
    integer, public,  parameter         :: COGLEY=2
 
    ! Longwave radiation
-   integer, public,  parameter         :: CLARK = 1               ! Clark et al, 1974
-   integer, public,  parameter         :: HASTENRATH_LAMB = 2     ! Hastenrath and Lamb, 1978
-   integer, public,  parameter         :: BIGNAMI = 3             ! Bignami et al., 1995 - Medsea
-   integer, public,  parameter         :: BERLIAND_BERLIAND = 4   ! Berliand and Berliand, 1952 - ROMS
-   integer, public,  parameter         :: JOSEY1 = 5              ! Josey 2003, (J1,9)
-   integer, public,  parameter         :: JOSEY2 = 6              ! Josey 2003, (J2,14)
+   integer, public,  parameter         :: CLARK = 3               ! Clark et al, 1974
+   integer, public,  parameter         :: HASTENRATH_LAMB = 4     ! Hastenrath and Lamb, 1978
+   integer, public,  parameter         :: BIGNAMI = 5             ! Bignami et al., 1995 - Medsea
+   integer, public,  parameter         :: BERLIAND_BERLIAND = 6   ! Berliand and Berliand, 1952 - ROMS
+   integer, public,  parameter         :: JOSEY1 = 7              ! Josey 2003, (J1,9)
+   integer, public,  parameter         :: JOSEY2 = 8              ! Josey 2003, (J2,14)
 !
 ! !REVISION HISTORY:
 !  Original author(s): Karsten Bolding, Hans Burchard


### PR DESCRIPTION
This is to address issue #65 .

longwave input now follow the standard layout: constant, file, other
all schemes to calculate longwaves have been shifted by 2:

```
   integer, public,  parameter         :: CLARK = 3               ! Clark et al, 1974
   integer, public,  parameter         :: HASTENRATH_LAMB = 4     ! Hastenrath and Lamb, 1978
   integer, public,  parameter         :: BIGNAMI = 5             ! Bignami et al., 1995 - Medsea
   integer, public,  parameter         :: BERLIAND_BERLIAND = 6   ! Berliand and Berliand, 1952 - ROMS
   integer, public,  parameter         :: JOSEY1 = 7              ! Josey 2003, (J1,9)
   integer, public,  parameter         :: JOSEY2 = 8              ! Josey 2003, (J2,14)
```

in the yaml file, the options should be as usual:

```
  longwave_radiation:
    method: constant
    constant_value: 10.0
```

or 

```
  longwave_radiation:
    method: file
    file: test.dat
```

or any other valid option: clark, etc..