### PR TITLE
z and zi not function of time in output when zeta is fixed and no ice model

### DIFF
--- a/src/gotm/gotm.F90
+++ b/src/gotm/gotm.F90
@@ -142,6 +142,7 @@
    REALTYPE :: ssf=_ZERO_ ! surface salinity flux
 
    integer(kind=timestepkind):: progress
+   logical :: fixed_grid
 !-----------------------------------------------------------------------
 
    contains
@@ -464,6 +465,7 @@
 !  However, before that happens, it is already used in updategrid.
 !  therefore, we set to to a reasonable default here.
    w_adv_input%method = 0
+   fixed_grid = (zeta_input%method == 0) .and. (ice_model == 0)
 
    restart = restart_online .or. restart_offline
    if (restart_online) restart_offline = .false.
@@ -583,7 +585,7 @@
    call post_init_seagrass(nlev)
 #endif
 
-   call do_register_all_variables(latitude,longitude,nlev)
+   call do_register_all_variables(latitude,longitude,fixed_grid,nlev)
 
    !  initialize FABM module
 #ifdef _FABM_

--- a/src/gotm/gotm.F90
+++ b/src/gotm/gotm.F90
@@ -83,6 +83,7 @@
    use gotm_fabm, only: fabm_airp, fabm_calendar_date, fabm_julianday
    use gotm_fabm_input,only: configure_gotm_fabm_input, init_gotm_fabm_input
 #endif
+   use register_all_variables,only: fixed_grid
 
    IMPLICIT NONE
    private
@@ -142,7 +143,6 @@
    REALTYPE :: ssf=_ZERO_ ! surface salinity flux
 
    integer(kind=timestepkind):: progress
-   logical :: fixed_grid
 !-----------------------------------------------------------------------
 
    contains
@@ -587,7 +587,7 @@
    call post_init_seagrass(nlev)
 #endif
 
-   call do_register_all_variables(latitude,longitude,fixed_grid,nlev)
+   call do_register_all_variables(latitude,longitude,nlev)
 
    !  initialize FABM module
 #ifdef _FABM_

--- a/src/gotm/gotm.F90
+++ b/src/gotm/gotm.F90
@@ -142,7 +142,7 @@
    REALTYPE :: ssf=_ZERO_ ! surface salinity flux
 
    integer(kind=timestepkind):: progress
-   logical :: fixed_grid
+   logical :: auto_z_grid
 !-----------------------------------------------------------------------
 
    contains
@@ -274,6 +274,8 @@
                    minimum=0._rk, default=0._rk)
    call branch%get(grid_file, 'file', 'path to file with layer thicknesses', &
                    default='')
+   call branch%get(auto_z_grid, 'auto_z_grid', &
+   'true: automatically detect fixed/dynamic vertical grid. false: force dynamic grid', default=.true.)
 #if 0
    twig => branch%get_child('adaptation')
    call twig%get(c1ad, 'c1ad', 'weighting factor for buoyancy frequency', '-', &
@@ -465,7 +467,9 @@
 !  However, before that happens, it is already used in updategrid.
 !  therefore, we set to to a reasonable default here.
    w_adv_input%method = 0
-   fixed_grid = (zeta_input%method == 0) .and. (ice_model == 0)
+   if (auto_z_grid) then
+       auto_z_grid = (zeta_input%method == 0) .and. (ice_model == 0)
+   end if
 
    restart = restart_online .or. restart_offline
    if (restart_online) restart_offline = .false.
@@ -585,7 +589,7 @@
    call post_init_seagrass(nlev)
 #endif
 
-   call do_register_all_variables(latitude,longitude,fixed_grid,nlev)
+   call do_register_all_variables(latitude,longitude,auto_z_grid,nlev)
 
    !  initialize FABM module
 #ifdef _FABM_

--- a/src/gotm/gotm.F90
+++ b/src/gotm/gotm.F90
@@ -142,7 +142,7 @@
    REALTYPE :: ssf=_ZERO_ ! surface salinity flux
 
    integer(kind=timestepkind):: progress
-   logical :: auto_z_grid
+   logical :: fixed_grid
 !-----------------------------------------------------------------------
 
    contains
@@ -274,8 +274,9 @@
                    minimum=0._rk, default=0._rk)
    call branch%get(grid_file, 'file', 'path to file with layer thicknesses', &
                    default='')
-   call branch%get(auto_z_grid, 'auto_z_grid', &
-   'true: automatically detect fixed/dynamic vertical grid. false: force dynamic grid', default=.true.)
+   call branch%get(fixed_grid, 'fixed_grid', &
+   'whether the vertical grid is fixed in time (enables static z coordinate in output)', &
+   default=.false.)
 #if 0
    twig => branch%get_child('adaptation')
    call twig%get(c1ad, 'c1ad', 'weighting factor for buoyancy frequency', '-', &
@@ -467,9 +468,6 @@
 !  However, before that happens, it is already used in updategrid.
 !  therefore, we set to to a reasonable default here.
    w_adv_input%method = 0
-   if (auto_z_grid) then
-       auto_z_grid = (zeta_input%method == 0) .and. (ice_model == 0)
-   end if
 
    restart = restart_online .or. restart_offline
    if (restart_online) restart_offline = .false.
@@ -589,7 +587,7 @@
    call post_init_seagrass(nlev)
 #endif
 
-   call do_register_all_variables(latitude,longitude,auto_z_grid,nlev)
+   call do_register_all_variables(latitude,longitude,fixed_grid,nlev)
 
    !  initialize FABM module
 #ifdef _FABM_

--- a/src/gotm/register_all_variables.F90
+++ b/src/gotm/register_all_variables.F90
@@ -38,7 +38,7 @@
 ! !ROUTINE: do_register_all_variables
 !
 ! !INTERFACE:
-   subroutine do_register_all_variables(lat,lon,nlev)
+   subroutine do_register_all_variables(lat,lon,fixed_grid,nlev)
 !
 ! !USES:
    IMPLICIT NONE
@@ -47,6 +47,7 @@
 !
 ! !INPUT PARAMETERS:
    REALTYPE, intent(in)                :: lat,lon
+   logical, intent(in)                 :: fixed_grid
    integer, intent(in)                 :: nlev
 !
 ! !REVISION HISTORY:
@@ -59,7 +60,7 @@
    LEVEL1 'register_all_variables()'
    call register_coordinate_variables(lat,lon)
    call register_density_variables(nlev)
-   call register_meanflow_variables(nlev)
+   call register_meanflow_variables(fixed_grid,nlev)
 #ifdef _SEAGRASS_
    call register_seagrass_variables(nlev)
 #endif
@@ -411,7 +412,7 @@
 ! !IROUTINE: meanflow variable registration
 !
 ! !INTERFACE:
-   subroutine register_meanflow_variables(nlev)
+   subroutine register_meanflow_variables(fixed_grid,nlev)
 !
 ! !DESCRIPTION:
 !
@@ -422,6 +423,7 @@
    IMPLICIT NONE
 !
 ! !INPUT PARAMETERS:
+   logical, intent(in)  :: fixed_grid
    integer, intent(in)  :: nlev
    type (type_field), pointer :: field
 !
@@ -472,10 +474,10 @@
       call fm%register('Af', 'm^2', 'hypsograph at grid interfaces', standard_name='??', dimensions=(/id_dim_z/), data1d=Af(1:nlev), category='column_structure')
    end if
 #endif
-   call fm%register('z', 'm', 'depth (center)', standard_name='??', dimensions=(/id_dim_z/), data1d=z(1:nlev), coordinate_dimension=id_dim_z,category='column_structure',field=field)
+   call fm%register('z', 'm', 'depth (center)', standard_name='??', dimensions=(/id_dim_z/), no_default_dimensions=fixed_grid, data1d=z(1:nlev), coordinate_dimension=id_dim_z,category='column_structure',field=field)
    call field%attributes%set('positive', 'up')
    call field%attributes%set('axis', 'Z')
-   call fm%register('zi', 'm', 'depth (interface)', standard_name='??', dimensions=(/id_dim_zi/), data1d=zi(0:nlev), coordinate_dimension=id_dim_zi,category='column_structure',field=field)
+   call fm%register('zi', 'm', 'depth (interface)', standard_name='??', dimensions=(/id_dim_zi/), no_default_dimensions=fixed_grid, data1d=zi(0:nlev), coordinate_dimension=id_dim_zi,category='column_structure',field=field)
    call field%attributes%set('positive', 'up')
    call field%attributes%set('axis', 'Z')
    call fm%register('h', 'm', 'layer thickness', standard_name='cell_thickness', dimensions=(/id_dim_z/), data1d=h(1:nlev),category='column_structure',part_of_state=.true.)

--- a/src/gotm/register_all_variables.F90
+++ b/src/gotm/register_all_variables.F90
@@ -38,7 +38,7 @@
 ! !ROUTINE: do_register_all_variables
 !
 ! !INTERFACE:
-   subroutine do_register_all_variables(lat,lon,auto_z_grid,nlev)
+   subroutine do_register_all_variables(lat,lon,fixed_grid,nlev)
 !
 ! !USES:
    IMPLICIT NONE
@@ -47,7 +47,7 @@
 !
 ! !INPUT PARAMETERS:
    REALTYPE, intent(in)                :: lat,lon
-   logical, intent(in)                 :: auto_z_grid
+   logical, intent(in)                 :: fixed_grid
    integer, intent(in)                 :: nlev
 !
 ! !REVISION HISTORY:
@@ -60,7 +60,7 @@
    LEVEL1 'register_all_variables()'
    call register_coordinate_variables(lat,lon)
    call register_density_variables(nlev)
-   call register_meanflow_variables(auto_z_grid,nlev)
+   call register_meanflow_variables(fixed_grid,nlev)
 #ifdef _SEAGRASS_
    call register_seagrass_variables(nlev)
 #endif
@@ -412,7 +412,7 @@
 ! !IROUTINE: meanflow variable registration
 !
 ! !INTERFACE:
-   subroutine register_meanflow_variables(auto_z_grid,nlev)
+   subroutine register_meanflow_variables(fixed_grid,nlev)
 !
 ! !DESCRIPTION:
 !
@@ -423,7 +423,7 @@
    IMPLICIT NONE
 !
 ! !INPUT PARAMETERS:
-   logical, intent(in)  :: auto_z_grid
+   logical, intent(in)  :: fixed_grid
    integer, intent(in)  :: nlev
    type (type_field), pointer :: field
 !
@@ -474,10 +474,10 @@
       call fm%register('Af', 'm^2', 'hypsograph at grid interfaces', standard_name='??', dimensions=(/id_dim_z/), data1d=Af(1:nlev), category='column_structure')
    end if
 #endif
-   call fm%register('z', 'm', 'depth (center)', standard_name='??', dimensions=(/id_dim_z/), no_default_dimensions=auto_z_grid, data1d=z(1:nlev), coordinate_dimension=id_dim_z,category='column_structure',field=field)
+   call fm%register('z', 'm', 'depth (center)', standard_name='??', dimensions=(/id_dim_z/), no_default_dimensions=fixed_grid, data1d=z(1:nlev), coordinate_dimension=id_dim_z,category='column_structure',field=field)
    call field%attributes%set('positive', 'up')
    call field%attributes%set('axis', 'Z')
-   call fm%register('zi', 'm', 'depth (interface)', standard_name='??', dimensions=(/id_dim_zi/), no_default_dimensions=auto_z_grid, data1d=zi(0:nlev), coordinate_dimension=id_dim_zi,category='column_structure',field=field)
+   call fm%register('zi', 'm', 'depth (interface)', standard_name='??', dimensions=(/id_dim_zi/), no_default_dimensions=fixed_grid, data1d=zi(0:nlev), coordinate_dimension=id_dim_zi,category='column_structure',field=field)
    call field%attributes%set('positive', 'up')
    call field%attributes%set('axis', 'Z')
    call fm%register('h', 'm', 'layer thickness', standard_name='cell_thickness', dimensions=(/id_dim_z/), data1d=h(1:nlev),category='column_structure',part_of_state=.true.)

--- a/src/gotm/register_all_variables.F90
+++ b/src/gotm/register_all_variables.F90
@@ -21,6 +21,7 @@
 !
 ! !PUBLIC DATA MEMBERS:
    type (type_field_manager), public, target :: fm
+   logical, public                           :: fixed_grid
 !
 ! !REVISION HISTORY:
 !  Original author(s): Karsten Bolding & Jorn Bruggeman
@@ -38,7 +39,7 @@
 ! !ROUTINE: do_register_all_variables
 !
 ! !INTERFACE:
-   subroutine do_register_all_variables(lat,lon,fixed_grid,nlev)
+   subroutine do_register_all_variables(lat,lon,nlev)
 !
 ! !USES:
    IMPLICIT NONE
@@ -47,7 +48,6 @@
 !
 ! !INPUT PARAMETERS:
    REALTYPE, intent(in)                :: lat,lon
-   logical, intent(in)                 :: fixed_grid
    integer, intent(in)                 :: nlev
 !
 ! !REVISION HISTORY:
@@ -60,7 +60,7 @@
    LEVEL1 'register_all_variables()'
    call register_coordinate_variables(lat,lon)
    call register_density_variables(nlev)
-   call register_meanflow_variables(fixed_grid,nlev)
+   call register_meanflow_variables(nlev)
 #ifdef _SEAGRASS_
    call register_seagrass_variables(nlev)
 #endif
@@ -412,7 +412,7 @@
 ! !IROUTINE: meanflow variable registration
 !
 ! !INTERFACE:
-   subroutine register_meanflow_variables(fixed_grid,nlev)
+   subroutine register_meanflow_variables(nlev)
 !
 ! !DESCRIPTION:
 !
@@ -423,7 +423,6 @@
    IMPLICIT NONE
 !
 ! !INPUT PARAMETERS:
-   logical, intent(in)  :: fixed_grid
    integer, intent(in)  :: nlev
    type (type_field), pointer :: field
 !

--- a/src/gotm/register_all_variables.F90
+++ b/src/gotm/register_all_variables.F90
@@ -38,7 +38,7 @@
 ! !ROUTINE: do_register_all_variables
 !
 ! !INTERFACE:
-   subroutine do_register_all_variables(lat,lon,fixed_grid,nlev)
+   subroutine do_register_all_variables(lat,lon,auto_z_grid,nlev)
 !
 ! !USES:
    IMPLICIT NONE
@@ -47,7 +47,7 @@
 !
 ! !INPUT PARAMETERS:
    REALTYPE, intent(in)                :: lat,lon
-   logical, intent(in)                 :: fixed_grid
+   logical, intent(in)                 :: auto_z_grid
    integer, intent(in)                 :: nlev
 !
 ! !REVISION HISTORY:
@@ -60,7 +60,7 @@
    LEVEL1 'register_all_variables()'
    call register_coordinate_variables(lat,lon)
    call register_density_variables(nlev)
-   call register_meanflow_variables(fixed_grid,nlev)
+   call register_meanflow_variables(auto_z_grid,nlev)
 #ifdef _SEAGRASS_
    call register_seagrass_variables(nlev)
 #endif
@@ -412,7 +412,7 @@
 ! !IROUTINE: meanflow variable registration
 !
 ! !INTERFACE:
-   subroutine register_meanflow_variables(fixed_grid,nlev)
+   subroutine register_meanflow_variables(auto_z_grid,nlev)
 !
 ! !DESCRIPTION:
 !
@@ -423,7 +423,7 @@
    IMPLICIT NONE
 !
 ! !INPUT PARAMETERS:
-   logical, intent(in)  :: fixed_grid
+   logical, intent(in)  :: auto_z_grid
    integer, intent(in)  :: nlev
    type (type_field), pointer :: field
 !
@@ -474,10 +474,10 @@
       call fm%register('Af', 'm^2', 'hypsograph at grid interfaces', standard_name='??', dimensions=(/id_dim_z/), data1d=Af(1:nlev), category='column_structure')
    end if
 #endif
-   call fm%register('z', 'm', 'depth (center)', standard_name='??', dimensions=(/id_dim_z/), no_default_dimensions=fixed_grid, data1d=z(1:nlev), coordinate_dimension=id_dim_z,category='column_structure',field=field)
+   call fm%register('z', 'm', 'depth (center)', standard_name='??', dimensions=(/id_dim_z/), no_default_dimensions=auto_z_grid, data1d=z(1:nlev), coordinate_dimension=id_dim_z,category='column_structure',field=field)
    call field%attributes%set('positive', 'up')
    call field%attributes%set('axis', 'Z')
-   call fm%register('zi', 'm', 'depth (interface)', standard_name='??', dimensions=(/id_dim_zi/), no_default_dimensions=fixed_grid, data1d=zi(0:nlev), coordinate_dimension=id_dim_zi,category='column_structure',field=field)
+   call fm%register('zi', 'm', 'depth (interface)', standard_name='??', dimensions=(/id_dim_zi/), no_default_dimensions=auto_z_grid, data1d=zi(0:nlev), coordinate_dimension=id_dim_zi,category='column_structure',field=field)
    call field%attributes%set('positive', 'up')
    call field%attributes%set('axis', 'Z')
    call fm%register('h', 'm', 'layer thickness', standard_name='cell_thickness', dimensions=(/id_dim_z/), data1d=h(1:nlev),category='column_structure',part_of_state=.true.)


### PR DESCRIPTION
This PR address the old (and closed...) issue #45. 

With these minor modifications, we can have a stationary z grid in the netcdf file (i.e. z and zi do not depend on time). this is *very* helpful in many ways: when loading the netcdf in python and with ncview to get the correct z axis.

z axis function of time should should still work when zeta varies or when there is an ice model.

the idea is just to compute a flag
` fixed_grid = (zeta_input%method == 0) .and. (ice_model == 0)`
in gotm.F90

and then in register_variables, decide whether or not z and zi are function of time based on this flag
 
side note (not implemented here): we could also envision that lat and lon are function of time (following an argo float for instance). but yes, it is convenient to have fixed lat lon (current behavior)